### PR TITLE
Install python3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,20 @@ ADD matlab.txt /mcr-install/matlab.txt
 RUN apt-get update && \
 	apt-get install -y curl wget unzip xorg
 
+# Install python 3.7 (build from sources, because it's not yet in the debian repos)
+RUN apt-get install make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
+	libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev && \
+	cd /usr/local && \
+	wget https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz && \
+	tar xzf Python-3.7.3.tgz && \
+	cd Python-3.7.3 && \
+	./configure --with-ensurepip=install && \
+	make && \
+	make altinstall && \
+	chmod +x python3.7 && \
+	cd /
+
+
 # Install MATLAB runtime
 RUN \
 	cd /mcr-install && \


### PR DESCRIPTION
https://scalablecapital.atlassian.net/browse/FINEBAC-651

Not sure, if we want to do it that way. Probably it's better to create a separate image `FROM docker-java-matlab` that also includes python.