### PR TITLE
Switch to 8-jre tag for the openjdk Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u151-jre
+FROM openjdk:8-jre
 
 MAINTAINER Florian Benz
 


### PR DESCRIPTION
This ensures that the latest update for Java 8 is pulled.